### PR TITLE
Require core modules instead of php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,10 @@
     "name": "imi/m2-breadcrumbs",
     "description": "",
     "require": {
-        "php": "~7.0.0|~7.1.0|~7.2.0"
+        "magento/framework": "^102.0.0|^103.0.0",
+        "magento/module-customer": "^102.0.0|^103.0.0",
+        "magento/module-store": "^101.0.0",
+        "magento/module-theme": "^101.0.0"
     },
     "suggest": {
 


### PR DESCRIPTION
Requires the modules for Magento 2.3.x and Magento 2.4.x